### PR TITLE
Only copy requestedHostId from main to secondary services if it exists

### DIFF
--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -153,7 +153,8 @@ def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, 
     upgrade['inServiceStrategy']['launchConfig'] = service['launchConfig']
 
     for secondaryLaunchConfig in service['secondaryLaunchConfigs']:
-        secondaryLaunchConfig['requestedHostId'] = service['launchConfig']['requestedHostId']
+        if 'requestedHostId' in service['launchConfig']:
+            secondaryLaunchConfig['requestedHostId'] = service['launchConfig']['requestedHostId']
         upgrade['inServiceStrategy']['secondaryLaunchConfigs'].append(secondaryLaunchConfig.copy())
 
     if new_image:


### PR DESCRIPTION
Just added a check if there's a requestedHostId in the service before copying. It breaks without the test.